### PR TITLE
Update catalogsource-operators-coreos-com-v1alpha1.adoc

### DIFF
--- a/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.adoc
+++ b/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.adoc
@@ -164,7 +164,7 @@ Type::
 | `string`
 | SecurityContextConfig can be one of `legacy` or `restricted`. The CatalogSource's pod is either injected with the right pod.spec.securityContext and pod.spec.container[*].securityContext values to allow the pod to run in Pod Security Admission (PSA) `restricted` mode, or doesn't set these values at all, in which case the pod can only be run in PSA `baseline` or `privileged` namespaces. Currently if the SecurityContextConfig is unspecified, the default value of `legacy` is used. Specifying a value other than `legacy` or `restricted` result in a validation error. When using older catalog images, which could not be run in `restricted` mode, the SecurityContextConfig should be set to `legacy`. 
  In a future version will the default will be set to `restricted`, catalog maintainers should rebuild their catalogs with a version of opm that supports running catalogSource pods in `restricted` mode to prepare for these changes. 
- More information about PSA can be found here: https://kubernetes.io/docs/concepts/security/pod-security-admission/'
+ More information about PSA can be found here: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 
 | `tolerations`
 | `array`


### PR DESCRIPTION
Description:

Corrected a small typo inside section: CatalogSource/.spec.grpcPodConfig.securityContextConfig

> There is a small typo in this sentence because of which an additional acute/back quote symbol (`)  got inserted at the end of the URL "https://kubernetes.io/docs/concepts/security/pod-security-admission/". Upon clicking on this URL, its redirecting to 404 error. Hence I removed it.

Version(s): 4.12-4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  

https://github.com/shubhamtango/openshift-docs/blob/main/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.adoc

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
